### PR TITLE
Fixed small bug in dh.getStats

### DIFF
--- a/R/get-stats.R
+++ b/R/get-stats.R
@@ -220,7 +220,6 @@ check with ds.class \n\n",
 
   vars_long <- left_join(vars_long, classes, by = "variable")
 
-
   ## ---- Final reference table for factors --------------------------------------
   fact_ref <- vars_long %>%
     dplyr::filter(type == "factor")
@@ -367,20 +366,20 @@ check with ds.class \n\n",
   ################################################################################
   # Check for invalid cases
   ################################################################################
-  
+
   invalid <- data.frame()
   if (nrow(fact_ref) > 0) {
     invalid <- stats_cat %>% dplyr::filter(str_detect(category, "Failed"))
     stats_cat <- stats_cat %>% dplyr::filter(!str_detect(category, "Failed"))
   }
-  
-  if(nrow(invalid) > 0){
-    
+
+  if (nrow(invalid) > 0) {
     warning("These variables have insufficient cell count for at least
             one cohort and have been removed:")
-    
-    invalid %>% dplyr::select(variable, cohort) %>% print
-    
+
+    invalid %>%
+      dplyr::select(variable, cohort) %>%
+      print()
   }
 
   ################################################################################

--- a/R/get-stats.R
+++ b/R/get-stats.R
@@ -367,7 +367,12 @@ check with ds.class \n\n",
   ################################################################################
   # Check for invalid cases
   ################################################################################
-  invalid <- stats_cat %>% dplyr::filter(str_detect(category, "Failed"))
+  
+  invalid <- data.frame()
+  if (nrow(fact_ref) > 0) {
+    invalid <- stats_cat %>% dplyr::filter(str_detect(category, "Failed"))
+    stats_cat <- stats_cat %>% dplyr::filter(!str_detect(category, "Failed"))
+  }
   
   if(nrow(invalid) > 0){
     
@@ -377,9 +382,7 @@ check with ds.class \n\n",
     invalid %>% dplyr::select(variable, cohort) %>% print
     
   }
-  
-  stats_cat <- stats_cat %>% dplyr::filter(!str_detect(category, "Failed"))
-  
+
   ################################################################################
   # 9. Calculate combined stats for categorical variables
   ################################################################################


### PR DESCRIPTION
On the current release, there is a problem here https://github.com/lifecycle-project/ds-helper/blob/master/R/get-stats.R#L370, when you are calling the `dh.getStats` function only with numerical variables, the variable `stats_cat` is empty, therefore this lines returns an error.

The error can be reproduced using the following code:
(dsBaseClient 6.1.1 / dsHelper 0.4.11)

```
library(DSI)
library(DSOpal)
library(dsBaseClient)

builder <- DSI::newDSLoginBuilder()
builder$append(server = "study1",
               url = "https://opal-demo.obiba.org",
               user = "dsuser", password = "P@ssw0rd")
logindata <- builder$build()
connections <- DSI::datashield.login(logins = logindata)
DSI::datashield.assign.table(connections, "table1", "CNSIM.CNSIM1")
dsHelper::dh.getStats("table1", "LAB_TSC")
```

Any yields the error: 
```
Error in dplyr::filter(., str_detect(category, "Failed")) : 
  object 'stats_cat' not found
```

The solution I propose makes sure that the `stats_cat` object is only used when `nrow(fact_ref) > 0` is `TRUE`, which here https://github.com/lifecycle-project/ds-helper/blob/master/R/get-stats.R#L354 will create the `stats_cat` variable.
